### PR TITLE
Fixed name attribute in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,6 +22,6 @@
     "fonts/fontawesome-webfont.ttf",
     "fonts/fontawesome-webfont.woff"
   ],
-  "name": "angular-ui-router-breadcrumbs",
+  "name": "font-awesome-bower",
   "version": "4.1.0"
 }


### PR DESCRIPTION
The name attribute, `angular-ui-router-breadcrumbs`, is wrong. This pull request changes it to `font-awesome-bower`.
